### PR TITLE
fix: UnhandledPromiseRejectionWarning

### DIFF
--- a/src/api/base.js
+++ b/src/api/base.js
@@ -1,12 +1,12 @@
 export const error = (res, err) => {
   const message = err.toString();
 
+  res.type('json');
+  res.status = 500;
   res.json({
     status: 'error',
     message
   });
-  res.status = 500;
-  res.type('json');
 };
 
 export const success = (res, result) => {
@@ -18,7 +18,7 @@ export const success = (res, result) => {
     response.result = result;
   }
 
-  res.json(response);
-  res.status = 200;
   res.type('json');
+  res.status = 200;
+  res.json(response);
 };


### PR DESCRIPTION
Fixes the following error by moving the `res.type()` call before `res.json()`.

```
(node:3786) UnhandledPromiseRejectionWarning: Error: Can't set headers after they are sent.
    at validateHeader (_http_outgoing.js:491:11)
    at ServerResponse.setHeader (_http_outgoing.js:498:3)
    at ServerResponse.header (/Users/chrisvogt/Dev/js-personal-api/node_modules/express/lib/response.js:767:10)
    at ServerResponse.send (/Users/chrisvogt/Dev/js-personal-api/node_modules/express/lib/response.js:170:12)
    at ServerResponse.json (/Users/chrisvogt/Dev/js-personal-api/node_modules/express/lib/response.js:267:15)
    at Object.exports.error (/Users/chrisvogt/Dev/js-personal-api/build/api/base.js:9:7)
    at controller.getProjects.then.catch.err (/Users/chrisvogt/Dev/js-personal-api/build/api/projects.js:19:94)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
(node:3786) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:3786) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:3786) UnhandledPromiseRejectionWarning: Error: Can't set headers after they are sent.
    at validateHeader (_http_outgoing.js:491:11)
    at ServerResponse.setHeader (_http_outgoing.js:498:3)
    at ServerResponse.header (/Users/chrisvogt/Dev/js-personal-api/node_modules/express/lib/response.js:767:10)
    at ServerResponse.send (/Users/chrisvogt/Dev/js-personal-api/node_modules/express/lib/response.js:170:12)
    at ServerResponse.json (/Users/chrisvogt/Dev/js-personal-api/node_modules/express/lib/response.js:267:15)
    at Object.exports.error (/Users/chrisvogt/Dev/js-personal-api/build/api/base.js:9:7)
    at controller.getProjectsWithRepos.then.catch.err (/Users/chrisvogt/Dev/js-personal-api/build/api/projects.js:23:103)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
(node:3786) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
```