### PR TITLE
chore: add unit tests for the projects controller

### DIFF
--- a/test/_fixtures/res.js
+++ b/test/_fixtures/res.js
@@ -1,7 +1,7 @@
 const res = {
-  json: {},
+  json: () => {},
   status: 0,
-  type: {}
+  type: () => {}
 };
 
 export default res;

--- a/test/api/base.js
+++ b/test/api/base.js
@@ -2,16 +2,11 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import { error, success } from '../../src/api/base';
+import res from '../_fixtures/res';
 
 const sandbox = sinon.createSandbox();
 
 describe('API: base', () => {
-  const res = {
-    json: () => {},
-    status: 0,
-    type: () => {}
-  };
-
   beforeEach(() => {
     sandbox.stub(res, 'json');
     sandbox.stub(res, 'type');

--- a/test/controllers/projects.js
+++ b/test/controllers/projects.js
@@ -4,7 +4,17 @@ import sinon from 'sinon';
 
 import projectFixture from '../_fixtures/project';
 
-const stubGetAllDocuments = sinon.stub();
+const mockJoinResponse = {
+  repository: {
+    meta: {
+      name: 'ACME Repository'
+    }
+  }
+};
+
+const sandbox = sinon.createSandbox();
+const stubGetAllDocuments = sandbox.stub();
+const stubJoinRepoToProject = sandbox.stub().returns(mockJoinResponse);
 
 const {
   getProjects,
@@ -12,15 +22,20 @@ const {
 } = proxyquire
   .noCallThru()
   .load('../../src/controllers/projects.js', {
+    '../helpers/joinRepoToProject': stubJoinRepoToProject,
     '../database/services': {
       getAllDocuments: stubGetAllDocuments
     }
 });
 
 describe('project controller', () => {
+  afterEach(() => {
+    sandbox.resetHistory();
+  });
+
   describe('getProjects', () => {
     const projectsArr = [projectFixture, projectFixture];
-    let allDocuments
+    let allDocuments;
 
     beforeEach(async () => {
       stubGetAllDocuments.resolves(projectsArr);
@@ -33,6 +48,29 @@ describe('project controller', () => {
 
     it('returns the projects', () => {
       expect(allDocuments).to.deep.equal(projectsArr);
-    })
-  })
+    });
+  });
+
+  describe('getProjectsWithRepos', () => {
+    const projectsArr = [projectFixture, projectFixture];
+    const joinedProjectsArr = new Array(projectsArr.length).fill(mockJoinResponse);
+    let allDocuments;
+
+    beforeEach(async () => {
+      stubGetAllDocuments.resolves(projectsArr);
+      allDocuments = await getProjectsWithRepos();
+    });
+
+    it('queries the projects collection', () => {
+      expect(stubGetAllDocuments.args).to.deep.equal([['projects']]);
+    });
+
+    it('maps each project to the project repo', () => {
+      expect(stubJoinRepoToProject.args).to.deep.equal(stubJoinRepoToProject.args);
+    });
+
+    it('returns the projects with repo data attached', () => {
+      expect(allDocuments).to.deep.equal(joinedProjectsArr);
+    });
+  });
 });


### PR DESCRIPTION
This PR adds unit tests for the projects controller. It also refactors the API base module test to use the `res` fixture.