### PR TITLE
 feat: add response caching using apicache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -660,6 +660,11 @@
         "normalize-path": "^2.0.0"
       }
     },
+    "apicache": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/apicache/-/apicache-1.2.3.tgz",
+      "integrity": "sha512-w4FpqHII+hi34Ujwbj6Pgkm3NHBmVZp8JiBmyedz5Qcq/HKqLi5rqYo7Tc/9QtWEPiP1cTxd026V/ZS02/sTXA=="
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "repository": {},
   "dependencies": {
     "@octokit/rest": "^15.10.0",
+    "apicache": "^1.2.3",
     "chalk": "^2.4.1",
     "cors": "^2.8.4",
     "dotenv": "^6.0.0",

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,6 +4,7 @@ export default {
     PROJECTS: 'projects',
     REPOSITORIES: 'repositories',
   },
+  DEFAULT_CACHE_TIME: '3 hours',
   PORT: 3000,
   STRINGS: {
     CREATED_NEW_REPOSITORY: 'added repository for $NAME',

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,8 +1,13 @@
+import apicache from 'apicache';
+
 import { getProjects, getProjectsWithRepos } from './api/projects';
 import { getRepositories } from './api/repositories';
 
+const cacheOptions = { debug: true };
+const cache = apicache.options(cacheOptions).middleware;
+
 export default (app) => {
-  app.get('/projects', getProjects);
-  app.get('/projectsWithRepos', getProjectsWithRepos);
-  app.get('/repositories', getRepositories);
+  app.get('/projects', cache('3 hours'), getProjects);
+  app.get('/projectsWithRepos', cache('3 hours'), getProjectsWithRepos);
+  app.get('/repositories', cache('3 hours'), getRepositories);
 };

--- a/src/routes.js
+++ b/src/routes.js
@@ -4,7 +4,7 @@ import constants from './constants';
 import { getProjects, getProjectsWithRepos } from './api/projects';
 import { getRepositories } from './api/repositories';
 
-const cacheOptions = { debug: true };
+const cacheOptions = { debug: process.env.NODE_ENV !== 'production' };
 const cache = apicache.options(cacheOptions).middleware;
 const { DEFAULT_CACHE_TIME } = constants;
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,13 +1,15 @@
 import apicache from 'apicache';
 
+import constants from './constants';
 import { getProjects, getProjectsWithRepos } from './api/projects';
 import { getRepositories } from './api/repositories';
 
 const cacheOptions = { debug: true };
 const cache = apicache.options(cacheOptions).middleware;
+const { DEFAULT_CACHE_TIME } = constants;
 
 export default (app) => {
-  app.get('/projects', cache('3 hours'), getProjects);
-  app.get('/projectsWithRepos', cache('3 hours'), getProjectsWithRepos);
-  app.get('/repositories', cache('3 hours'), getRepositories);
+  app.get('/projects', cache(DEFAULT_CACHE_TIME), getProjects);
+  app.get('/projectsWithRepos', cache(DEFAULT_CACHE_TIME), getProjectsWithRepos);
+  app.get('/repositories', cache(DEFAULT_CACHE_TIME), getRepositories);
 };


### PR DESCRIPTION
This PR adds the initial work for caching responses, using the [apicache](https://github.com/kwhitley/apicache) middleware.

#### Before caching

```
GET /projects 200 1279.606 ms - 2295
GET /projects 200 108.492 ms - 2295
GET /projects 200 158.529 ms - 2295
```

#### With caching

```
[apicache] adding cache entry for "/projects" @ 3 hours - 1.11sec
[apicache] _apicache.headers:
[apicache] res._headers:  { 'x-powered-by': 'Express',
  'access-control-allow-origin': '*',
  'content-type': 'application/json; charset=utf-8',
  'content-length': '2295',
  etag: 'W/"8f7-gFQiyKNc6i6/LIZhfhv8EJHw/00"' }
[apicache] cacheObject:  { status: 200,
  headers:
   { 'x-powered-by': 'Express',
     'access-control-allow-origin': '*',
     'content-type': 'application/json; charset=utf-8',
     'content-length': '2295',
     etag: 'W/"8f7-gFQiyKNc6i6/LIZhfhv8EJHw/00"' },
  data: <Buffer 7b 22 73 74 61 74 75 73 22 3a 22 6f 6b 22 2c 22 72 65 73 75 6c 74 22 3a 7b 22 70 72 6f 6a 65 63 74 73 22 3a 5b 7b 22 73 6c 75 67 22 3a 22 63 68 72 69 ... >,
  encoding: undefined }
GET /projects 200 1117.220 ms - 2295
[apicache] sending cached (memory-cache) version of /projects - 0ms
GET /projects 304 0.443 ms - 2295
[apicache] sending cached (memory-cache) version of /projects - 0ms
GET /projects 304 0.231 ms - 2295
```