### PR TITLE
fix: handle cases where projects don't have repository data available

### DIFF
--- a/src/helpers/joinRepoToProject.js
+++ b/src/helpers/joinRepoToProject.js
@@ -6,14 +6,16 @@ const { REPOSITORIES } = constants.COLLECTIONS;
 
 const joinRepoToProject = async (project) => {
   const ref = getRepositoryRef(project);
-  const repository = await getDocumentById(ref, REPOSITORIES);
+  const repository = ref ? await getDocumentById(ref, REPOSITORIES) : null;
 
   const updatedProject = {
     ...project,
-    repository: {
-      ...project.repository,
-      meta: repository.data(),
-    },
+    ...(repository ? {
+      repository: {
+        ...project.repository,
+        meta: repository.data(),
+      },
+    } : {}),
   };
 
   return updatedProject;

--- a/src/models/project.js
+++ b/src/models/project.js
@@ -4,6 +4,14 @@ export const getName = project => project.name;
 
 export const getRepositoryProviderId = project => project.repository.providerId;
 
-export const getRepositoryRef = project => project.repository.ref;
+export const getRepositoryRef = (project) => {
+  const {
+    repository: {
+      ref,
+    } = {},
+  } = project;
+
+  return ref;
+};
 
 export default getProject;

--- a/test/helpers/joinRepoToProject.js
+++ b/test/helpers/joinRepoToProject.js
@@ -18,8 +18,10 @@ const mockResult = {
   data: () => mockRepository,
 };
 
+const stubGetRepositoryRef = sinon.stub();
+
 const projects = {
-  getRepositoryRef: sinon.stub().returns(mockProject.repository.ref),
+  getRepositoryRef: stubGetRepositoryRef,
 };
 
 const services = {
@@ -34,7 +36,8 @@ const joinRepoToProject = proxyquire('../../src/helpers/joinRepoToProject.js', {
 }).default;
 
 describe('joinRepoToProject helper', async () => {
-  it('it joins the requested repository', async () => {
+  it('joins the requested repository', async () => {
+    stubGetRepositoryRef.resolves(mockProject.repository.ref);
     const result = await joinRepoToProject(mockProject);
 
     expect(result).to.deep.equal({
@@ -44,5 +47,12 @@ describe('joinRepoToProject helper', async () => {
         meta: mockRepository,
       },
     });
+  });
+
+  it('returns the project if no repository is found', async () => {
+    stubGetRepositoryRef.returns(null);
+    const result = await joinRepoToProject(mockProject);
+
+    expect(result).to.deep.equal(mockProject);
   });
 });

--- a/test/models/project.js
+++ b/test/models/project.js
@@ -37,6 +37,6 @@ describe('model: project getters', () => {
     it('returns undefined if not found', () => {
       const ref = getRepositoryRef({});
       expect(ref).to.deep.equal(undefined);
-    })
+    });
   });
 });

--- a/test/models/project.js
+++ b/test/models/project.js
@@ -33,5 +33,10 @@ describe('model: project getters', () => {
       const ref = getRepositoryRef(projectFixture);
       expect(ref).to.deep.equal(projectFixture.repository.ref);
     });
+
+    it('returns undefined if not found', () => {
+      const ref = getRepositoryRef({});
+      expect(ref).to.deep.equal(undefined);
+    })
   });
 });


### PR DESCRIPTION
This PR fixes a bug in `master` where requesting the projects with repositories fails when it encounters a project without repository data available.

### Screenshot

_Current, live_

<img width="1065" alt="screen shot 2018-08-26 at 6 56 51 pm" src="https://user-images.githubusercontent.com/1934719/44636748-44258980-a962-11e8-9889-3e78a26f10de.png">

_With change_

<img width="1024" alt="screen shot 2018-08-26 at 6 57 57 pm" src="https://user-images.githubusercontent.com/1934719/44636768-5e5f6780-a962-11e8-8ddd-c1e04ae19431.png">
