### PR TITLE
feat: add routes for composite, meta, and profile data

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ The endpoints available are:
 
 | route | response |
 |---|---|
+| `GET /composite` | returns all collections |
+| `GET /metas` | get all meta data |
+| `GET /profiles` | get all profiles |
 | `GET /projects` | get all projects (param `repository=expanded` includes repository data) |
 | `GET /repositories` | get all repositories |
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,8 @@
 export default {
   APP_NAME: 'Personal API',
   COLLECTIONS: {
+    METAS: 'metas',
+    PROFILES: 'profiles',
     PROJECTS: 'projects',
     REPOSITORIES: 'repositories',
   },

--- a/src/controllers/composite.js
+++ b/src/controllers/composite.js
@@ -1,0 +1,30 @@
+import constants from '../constants';
+import { getAllDocuments } from '../database/services';
+import { sendError, sendSuccess } from '../api/base';
+
+const {
+  METAS,
+  PROFILES,
+  PROJECTS,
+  REPOSITORIES,
+} = constants.COLLECTIONS;
+
+const getComposite = async (req, res) => {
+  try {
+    const metas = await getAllDocuments(METAS);
+    const profiles = await getAllDocuments(PROFILES);
+    const projects = await getAllDocuments(PROJECTS);
+    const repositories = await getAllDocuments(REPOSITORIES);
+
+    sendSuccess(res, {
+      metas,
+      profiles,
+      projects,
+      repositories,
+    });
+  } catch (error) {
+    sendError(res, { error });
+  }
+};
+
+export default getComposite;

--- a/src/controllers/metas.js
+++ b/src/controllers/metas.js
@@ -1,0 +1,16 @@
+import constants from '../constants';
+import { getAllDocuments } from '../database/services';
+import { sendError, sendSuccess } from '../api/base';
+
+const { METAS } = constants.COLLECTIONS;
+
+const getMetas = async (req, res) => {
+  try {
+    const metas = await getAllDocuments(METAS);
+    sendSuccess(res, { metas });
+  } catch (error) {
+    sendError(res, { error });
+  }
+};
+
+export default getMetas;

--- a/src/controllers/profiles.js
+++ b/src/controllers/profiles.js
@@ -1,0 +1,16 @@
+import constants from '../constants';
+import { getAllDocuments } from '../database/services';
+import { sendError, sendSuccess } from '../api/base';
+
+const { PROFILES } = constants.COLLECTIONS;
+
+const getProfiles = async (req, res) => {
+  try {
+    const profiles = await getAllDocuments(PROFILES);
+    sendSuccess(res, { profiles });
+  } catch (error) {
+    sendError(res, { error });
+  }
+};
+
+export default getProfiles;

--- a/src/routes.js
+++ b/src/routes.js
@@ -16,7 +16,7 @@ const cache = apicache.options(cacheOptions).middleware;
 const { DEFAULT_CACHE_TIME } = constants;
 
 export default (app) => {
-  app.use('/composite', cache(DEFAULT_CACHE_TIME), getComposite)
+  app.use('/composite', cache(DEFAULT_CACHE_TIME), getComposite);
   app.use('/metas', cache(DEFAULT_CACHE_TIME), getMetas);
   app.use('/profiles', cache(DEFAULT_CACHE_TIME), getProfiles);
   app.use('/projects', cache(DEFAULT_CACHE_TIME), getProjects);

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,6 +1,8 @@
 import apicache from 'apicache';
 
 import constants from './constants';
+import getMetas from './controllers/metas';
+import getProfiles from './controllers/profiles';
 import getProjects from './controllers/projects';
 import getRepositories from './controllers/repositories';
 
@@ -13,6 +15,8 @@ const cache = apicache.options(cacheOptions).middleware;
 const { DEFAULT_CACHE_TIME } = constants;
 
 export default (app) => {
+  app.use('/metas', cache(DEFAULT_CACHE_TIME), getMetas);
+  app.use('/profiles', cache(DEFAULT_CACHE_TIME), getProfiles);
   app.use('/projects', cache(DEFAULT_CACHE_TIME), getProjects);
   app.use('/repositories', cache(DEFAULT_CACHE_TIME), getRepositories);
 };

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,6 +1,7 @@
 import apicache from 'apicache';
 
 import constants from './constants';
+import getComposite from './controllers/composite';
 import getMetas from './controllers/metas';
 import getProfiles from './controllers/profiles';
 import getProjects from './controllers/projects';
@@ -15,6 +16,7 @@ const cache = apicache.options(cacheOptions).middleware;
 const { DEFAULT_CACHE_TIME } = constants;
 
 export default (app) => {
+  app.use('/composite', cache(DEFAULT_CACHE_TIME), getComposite)
   app.use('/metas', cache(DEFAULT_CACHE_TIME), getMetas);
   app.use('/profiles', cache(DEFAULT_CACHE_TIME), getProfiles);
   app.use('/projects', cache(DEFAULT_CACHE_TIME), getProjects);

--- a/test/_fixtures/meta.js
+++ b/test/_fixtures/meta.js
@@ -1,0 +1,11 @@
+const metaFixture = {
+  key: 'socialProfilesOrder',
+  order: [
+    'twitter',
+    'linkedin',
+    'github',
+    'stack-overflow',
+  ],
+};
+
+export default metaFixture;

--- a/test/_fixtures/profile.js
+++ b/test/_fixtures/profile.js
@@ -1,0 +1,13 @@
+const profileFixture = {
+  displayName: 'Instagram',
+  href: 'https://instagram.com/c1v0',
+  icon: {
+    class: 'fa fa-instagram',
+    name: 'instagram',
+    reactIcon: 'instagram',
+    set: 'fa',
+  },
+  slug: 'instagram',
+};
+
+export default profileFixture;

--- a/test/controllers/composite.js
+++ b/test/controllers/composite.js
@@ -1,0 +1,85 @@
+import { expect } from 'chai';
+import proxyquire from 'proxyquire';
+import sinon from 'sinon';
+
+import constants from '../../src/constants';
+
+const {
+  METAS,
+  PROFILES,
+  PROJECTS,
+  REPOSITORIES,
+} = constants.COLLECTIONS;
+
+const sandbox = sinon.createSandbox();
+const stubGetAllDocuments = sandbox.stub();
+const stubSendError = sandbox.stub();
+const stubSendSuccess = sandbox.stub();
+
+const getComposite = proxyquire
+  .noCallThru()
+  .load('../../src/controllers/composite.js', {
+    '../api/base': {
+      sendError: stubSendError,
+      sendSuccess: stubSendSuccess,
+    },
+    '../database/services': {
+      getAllDocuments: stubGetAllDocuments,
+    },
+  }).default;
+
+describe('composite controller', () => {
+  const req = { query: {} };
+  const res = sandbox.stub();
+
+  afterEach(() => {
+    sandbox.resetHistory();
+  });
+
+  describe('getComposite()', () => {
+    before(() => {
+      stubGetAllDocuments.withArgs(METAS).resolves(METAS);
+      stubGetAllDocuments.withArgs(PROFILES).resolves(PROFILES);
+      stubGetAllDocuments.withArgs(PROJECTS).resolves(PROJECTS);
+      stubGetAllDocuments.withArgs(REPOSITORIES).resolves(REPOSITORIES);
+    });
+
+    it('calls getAllDocuments() for each entity', async () => {
+      await getComposite(req, res);
+      expect(stubGetAllDocuments.args).to.deep.equal([
+        [METAS],
+        [PROFILES],
+        [PROJECTS],
+        [REPOSITORIES],
+      ]);
+    });
+
+    it('returns the expected set of data', async () => {
+      await getComposite(req, res);
+      expect(stubSendSuccess.args).to.deep.equal([[res, {
+        [METAS]: METAS,
+        [PROFILES]: PROFILES,
+        [PROJECTS]: PROJECTS,
+        [REPOSITORIES]: REPOSITORIES,
+      }]]);
+    });
+  });
+
+  describe('error handling', () => {
+    const mockError = new Error('something went wrong');
+
+    before(() => {
+      stubGetAllDocuments.withArgs(METAS).rejects(mockError);
+    });
+
+    beforeEach(async () => {
+      await getComposite(req, res);
+    });
+
+    it('returns the error', () => {
+      expect(stubSendError.args).to.deep.equal([[res, {
+        error: mockError,
+      }]]);
+    });
+  });
+});

--- a/test/controllers/metas.js
+++ b/test/controllers/metas.js
@@ -1,0 +1,67 @@
+import { expect } from 'chai';
+import proxyquire from 'proxyquire';
+import sinon from 'sinon';
+
+import metaFixture from '../_fixtures/meta';
+
+const sandbox = sinon.createSandbox();
+const stubGetAllDocuments = sandbox.stub().resolves([metaFixture]);
+const stubSendError = sandbox.stub();
+const stubSendSuccess = sandbox.stub();
+
+const getMetas = proxyquire
+  .noCallThru()
+  .load('../../src/controllers/metas.js', {
+    '../api/base': {
+      sendError: stubSendError,
+      sendSuccess: stubSendSuccess,
+    },
+    '../database/services': {
+      getAllDocuments: stubGetAllDocuments,
+    },
+  }).default;
+
+describe('metas controller', () => {
+  const req = { query: {} };
+  const res = sandbox.stub();
+
+  afterEach(() => {
+    sandbox.resetHistory();
+  });
+
+  describe('getMetas', () => {
+    describe('default response', () => {
+      const metasArr = [metaFixture, metaFixture];
+
+      beforeEach(async () => {
+        stubGetAllDocuments.resolves(metasArr);
+        await getMetas(req, res);
+      });
+
+      it('queries the metas collection', () => {
+        expect(stubGetAllDocuments.args).to.deep.equal([['metas']]);
+      });
+
+      it('returns the metas', () => {
+        expect(stubSendSuccess.args).to.deep.equal([[res, {
+          metas: metasArr,
+        }]]);
+      });
+    });
+
+    describe('error handling', () => {
+      const mockError = new Error('something went wrong');
+
+      beforeEach(async () => {
+        stubGetAllDocuments.rejects(mockError);
+        await getMetas(req, res);
+      });
+
+      it('returns the error', () => {
+        expect(stubSendError.args).to.deep.equal([[res, {
+          error: mockError,
+        }]]);
+      });
+    });
+  });
+});

--- a/test/controllers/profiles.js
+++ b/test/controllers/profiles.js
@@ -1,0 +1,67 @@
+import { expect } from 'chai';
+import proxyquire from 'proxyquire';
+import sinon from 'sinon';
+
+import profileFixture from '../_fixtures/profile';
+
+const sandbox = sinon.createSandbox();
+const stubGetAllDocuments = sandbox.stub().resolves([profileFixture]);
+const stubSendError = sandbox.stub();
+const stubSendSuccess = sandbox.stub();
+
+const getProfiles = proxyquire
+  .noCallThru()
+  .load('../../src/controllers/profiles.js', {
+    '../api/base': {
+      sendError: stubSendError,
+      sendSuccess: stubSendSuccess,
+    },
+    '../database/services': {
+      getAllDocuments: stubGetAllDocuments,
+    },
+  }).default;
+
+describe('profiles controller', () => {
+  const req = { query: {} };
+  const res = sandbox.stub();
+
+  afterEach(() => {
+    sandbox.resetHistory();
+  });
+
+  describe('getProfiles', () => {
+    describe('default response', () => {
+      const profilesArr = [profileFixture, profileFixture];
+
+      beforeEach(async () => {
+        stubGetAllDocuments.resolves(profilesArr);
+        await getProfiles(req, res);
+      });
+
+      it('queries the profiles collection', () => {
+        expect(stubGetAllDocuments.args).to.deep.equal([['profiles']]);
+      });
+
+      it('returns the profiles', () => {
+        expect(stubSendSuccess.args).to.deep.equal([[res, {
+          profiles: profilesArr,
+        }]]);
+      });
+    });
+
+    describe('error handling', () => {
+      const mockError = new Error('something went wrong');
+
+      beforeEach(async () => {
+        stubGetAllDocuments.rejects(mockError);
+        await getProfiles(req, res);
+      });
+
+      it('returns the error', () => {
+        expect(stubSendError.args).to.deep.equal([[res, {
+          error: mockError,
+        }]]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR adds new routes for meta data, profiles data, and an endpoint (`composite`) to get all data at once.

#### Screenshots

_/metas_

<img width="1024" alt="screen shot 2018-08-26 at 8 45 58 pm" src="https://user-images.githubusercontent.com/1934719/44639500-23b0fb80-a971-11e8-8f22-353c943df90a.png">

_/profiles_

<img width="1024" alt="screen shot 2018-08-26 at 8 46 07 pm" src="https://user-images.githubusercontent.com/1934719/44639508-2c093680-a971-11e8-8ddd-a0a2ef587f9d.png">

_/composite_

<img width="1024" alt="screen shot 2018-08-26 at 8 46 12 pm" src="https://user-images.githubusercontent.com/1934719/44639511-31668100-a971-11e8-9ad4-5c455e76704f.png">
